### PR TITLE
feat: expose fstype and opts for nfs mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+[Changes](v2.1.0)
+
+
+<a name="v2.1.0"></a>
+# [v2.1.0](https://github.com/IBM/ansible-power-linux-sap/releases/tag/v2.1.0) - 17 May 2024
+
+## Features
+* Allow user to specify `opts` and `fstype` when mounting a `NFS` share.
+* README.md update for powervs_client_enable_services.
+
+
 [Changes](v2.0.0)
 
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -125,3 +125,9 @@ Notes
        * README.md has been reworked.
 Availability
        * GitHub v2.0.0(https://github.com/IBM/ansible-power-linux-sap)
+
+
+Version 2.1.0
+Notes
+       * Allow user to specify `opts` and `fstype` when mounting a `NFS` share.
+       * README.md update for powervs_client_enable_services.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "ibm"
 name: "power_linux_sap"
-version: "2.0.0"
+version: "2.1.0"
 readme: "README.md"
 description: RHEL/SLES ansible automation to prepare LPARs for installing SAP on Power Systems.
 authors:

--- a/playbooks/vars/sample-variables-powervs-client-enable-services.yml
+++ b/playbooks/vars/sample-variables-powervs-client-enable-services.yml
@@ -10,6 +10,8 @@ client_config:
     enable: false
     nfs_server_path: "10.51.0.121:/nfs;10.51.0.121:/software"
     nfs_client_path: "/nfs;/software"
+    opts: sec=sys,nfsvers=4.1,nofail
+    fstype: nfs4
   dns:
     enable: false
     dns_server_ip: "10.51.0.121"

--- a/roles/powervs_client_enable_services/README.md
+++ b/roles/powervs_client_enable_services/README.md
@@ -5,25 +5,39 @@
 This module is same for both SLES and RHEL.
 
 This role performs the following tasks:
-- Configures **SQUID** proxy.
-- Configures **DNS** server.
+- Configures **SQUID** proxy client.
+- Configures **DNS**.
 - Installs **NTP** packages and updates named.conf file with ntp server.
-- Installs **NFS** client packages, and mounts nfs exported directories as mentioned in variable file..
+- Installs **NFS** client packages, and mounts nfs exported directories as mentioned in variable file.
+- All above services will be **started and enabled**
 
-This role will also **start and enable** all above mentioned services.
+To execute this role the input variable **client_config** is required. The variable is defined below.
 
-The input variable **client_config** is needed to be provided for this role to be executed. The variable file looks like below
 ```
-client_config: {
-squid: { enable: false, squid_server_ip_port: "127.0.0.1:3128", no_proxy_hosts: "161.0.0.0/8" },
-ntp: { enable: false, ntp_server_ip: "127.0.0.1" },
-nfs: { enable: false, nfs_server_path: "127.0.0.1:/USER;127.0.0.1:/EXAMPLE", nfs_client_path: "/MNT;/HANA" },
-dns: { enable: false, dns_server_ip: "127.0.0.1" }
-}
+client_config:
+  squid:
+    enable: false
+    squid_server_ip_port: "10.51.0.121:3128"
+    no_proxy_hosts: "161.0.0.0/8"
+  ntp:
+    enable: false
+    ntp_server_ip: "10.51.0.121"
+  nfs:
+    enable: false
+    nfs_server_path: "10.51.0.121:/nfs;10.51.0.121:/software"
+    nfs_client_path: "/nfs;/software"
+    opts: sec=sys,nfsvers=4.1,nofail
+    fstype: nfs4
+  dns:
+    enable: false
+    dns_server_ip: "10.51.0.121"
 ```
-Each services can be chosen to be enabled or not. Disabling is not supported. This variable file enables users, to enable one or many services on one or multiple SAP instances, as desired.
 
-For **NFS** services, nfs server path, which are already shared, and can be mounted on client should be provided. **nfs_client_path** are directories where NFS shared directory will be locally mounted.
+## Notes
+- By default every service is `disabled`.
+- Each service can be chosen to be enabled or not by setting `enable: true`.
+- Disabling is not supported.
+- For **NFS** services, `nfs_server_path`, which are already shared, and can be mounted on client should be provided. `nfs_client_path` are directories where NFS shared directory will be locally mounted.
 
 ## Dependencies
 

--- a/roles/powervs_client_enable_services/tasks/main.yml
+++ b/roles/powervs_client_enable_services/tasks/main.yml
@@ -183,8 +183,8 @@
         src: "{{ item.1 }}"
         state: mounted
         boot: true
-        opts: defaults,nofail
-        fstype: nfs
+        opts: "{{ client_config.nfs.opts }}"
+        fstype: "{{ client_config.nfs.fstype }}"
       with_together:
         - "{{ client_config.nfs.nfs_client_path.split(';') }}"
         - "{{ client_config.nfs.nfs_server_path.split(';') }}"


### PR DESCRIPTION
Allow user to specify opts and fstype when mounting a NFS disk. 