### PR TITLE
v0.1 monitoring-sap: on new DA, one role, one playbook, role with mai…

### DIFF
--- a/playbooks/sample-monitoring-sap.yml
+++ b/playbooks/sample-monitoring-sap.yml
@@ -1,0 +1,26 @@
+---
+- name:  sap monitoring configuration
+  hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+  tasks:
+
+    - name: Execute the  role monitoring_sap
+      # include_role:
+      import_role:
+        name: { role: ../roles/monitoring_sap }
+      when: sap_monitoring_action == "add"
+
+      ##  Delete a SAP System from monitoring
+    - name: Check existence of the variables defined in roles/monitoring_sap/vars/main.yml
+      fail:
+        msg: 'variable {{ sap_monitoring_nr }} not defined in the file roles/monitoring_sap/vars/main.yml'
+      when: sap_monitoring_nr is not defined
+
+    - name: include role
+      include_role:
+        name: { role: ../roles/monitoring_sap }
+        tasks_from: sap-monitoring-configuration-deletion
+      when: sap_monitoring_action == "delete"
+
+      

--- a/playbooks/vars/sample-monitoring-sap-parameters.yml
+++ b/playbooks/vars/sample-monitoring-sap-parameters.yml
@@ -1,0 +1,39 @@
+
+# copy this file to roles/monitoring_sap/vars/main.yml and put in your SAP System parameters
+
+#monitoring meta parameter
+
+sap_monitoring_action: add
+#sap_monitoring_action: delete
+
+
+sap_monitoring_nr: "11"
+# sap_monitoring_nr: "95"
+sap_monitoring_solution_name: "PM2 6.1 (S/4 2022)"
+
+# IBM cloud parameters
+ibmcloud_monitoring_instance_url: https://ingest.prws.private.br-sao.monitoring.cloud.ibm.com/prometheus/remote/write 
+ibmcloud_monitoring_authorization_credentials: d9209057-f8c5-4f4d-a644-3400c261d572
+#ibmcloud_monitoring_authorization_credentials: 30262cb2-b114-4b69-9873-fbc93cb2afd9
+
+#hana parameters
+sap_hana_ip: 10.51.0.8
+sap_hana_http_port: 50213
+sap_hana_sql_systemdb_port: 30213
+sap_hana_sql_systemdb_user: monitoring-user
+sap_hana_sql_systemdb_password: NewPass123$
+
+#netweaver_parameters
+sap_ascs_ip: 10.51.0.81
+sap_ascs_http_port: 50013
+sap_app_server:
+  - sap_app_server_nr: 01
+    ip: 10.51.0.81
+    port: 50113
+  - sap_app_server_nr: 02
+    ip: 10.51.0.81
+    port: 50113
+  - sap_app_server_nr: 03
+    ip: 10.51.0.81
+    port: 50113
+

--- a/roles/monitoring_sap/tasks/hanadb-exporter-configuration.yml
+++ b/roles/monitoring_sap/tasks/hanadb-exporter-configuration.yml
@@ -1,0 +1,46 @@
+---
+# This playbook deploys prometheus-hanadb_exporter configuration on the monitoring host
+- name: Install prometheus-hanadb_exporter
+  ansible.builtin.zypper:
+    name: prometheus-hanadb_exporter
+    state: present
+  tags: prometheus-hanadb_exporter
+
+- name: Copy metrics.json from exporter-package to /etc/hanadb_exporter/.
+  become: true
+  ansible.builtin.copy:
+    remote_src: true
+    src: /usr/share/doc/packages/prometheus-hanadb_exporter/metrics.json
+    dest: /etc/hanadb_exporter/metrics.json
+    force: false
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Create a sap-hana-keystore for the  <sap_monitoring_nr>
+  ansible.builtin.shell:
+    cmd: '/usr/sap/hdbclient/hdbuserstore SET MONITORING{{ sap_monitoring_nr }}KEY {{ sap_hana_ip }}:{{ sap_hana_sql_systemdb_port }}@SYSTEMDB {{ sap_hana_sql_systemdb_user }} {{ sap_hana_sql_systemdb_password }}'
+    # cmd: '/usr/sap/hdbclient/hdbuserstore SET MONITORING-{{ sap_monitoring_nr }}-KEY {{ sap_hana_ip }}:{{ sap_hana_sql_systemdb_port }}@SYSTEMDB {{ sap_hana_sql_systemdb_user }} {{ sap_hana_sql_systemdb_password }}'
+
+- name: Check  sap-hana-keystore for 'MONITORING{{ sap_monitoring_nr }}KEY'
+  ansible.builtin.shell:
+    cmd: "/usr/sap/hdbclient/hdbuserstore LIST | grep MONITORING{{ sap_monitoring_nr }}KEY"
+  register: command_result
+  failed_when: "'MONITORING' + sap_monitoring_nr not in command_result.stdout"
+
+- name: Configure hanadb_exporter configuration file
+  ansible.builtin.template:
+    src: hanadb_exporter-config-SQL.json.conf.j2
+    dest: /etc/hanadb_exporter/config-{{ sap_monitoring_nr }}-SQL.json
+    owner: root
+    group: root
+    mode: '0600'
+  tags: hanadb_exporter
+
+# systemctl start prometheus-hanadb_exporter@config-{sap_monitoring_nr}-SQL
+- name: Start the systemd daemon of hanadb_exporter
+  ansible.builtin.systemd:
+    name: prometheus-hanadb_exporter@config-{{ sap_monitoring_nr }}-SQL
+    enabled: true
+    state: started
+  tags: hanadb_exporter

--- a/roles/monitoring_sap/tasks/main.yml
+++ b/roles/monitoring_sap/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+# This playbook checks, if SAP_HANA_CLIENT is insttalled  on the monitoring host 
+- name: Check existence of /usr/lib64/python3.6/site-packages/hdbcli/dbapi.py
+  stat:
+    path: /usr/lib64/python3.6/site-packages/hdbcli/dbapi.py
+  register: file_hana_driver
+
+- name: If SAP HANA client does not exist then install SAP HANA client
+  ansible.builtin.include_tasks: "{{ task }}.yml"
+  loop_control:
+    loop_var: task
+  loop:
+    - repos-activation        
+    - sap-hana-client-installation
+  when: not file_hana_driver.stat.exists and sap_monitoring_action == "add"
+    
+- name: Add one SAP System to the monitoring configuration
+  ansible.builtin.include_tasks: "{{ task }}.yml"
+  loop_control:
+    loop_var: task
+  loop:
+    - port-connectivity-check
+    - sap-host-exporter-configuration
+    - hanadb-exporter-configuration
+    - prometheus-agent-configuration
+  when: sap_monitoring_action == "add"
+
+##  Delete a SAP System from monitoring
+- name: Check existence of the variables defined in roles/monitoring_sap/vars/main.yml
+  fail:
+    msg: 'variable {{ sap_monitoring_nr }} not defined in the file roles/monitoring_sap/vars/main.yml '
+  when: sap_monitoring_nr is not defined
+
+  # - name: Delete one SAP System from the monitoring configuration
+  # ansible.builtin.include_tasks: sap-monitoring-configuration-deletion
+  # when: sap_monitoring_action == "delete"
+

--- a/roles/monitoring_sap/tasks/pause.yml
+++ b/roles/monitoring_sap/tasks/pause.yml
@@ -1,0 +1,7 @@
+---
+# This role pauses the deployment until user input
+
+- name: Pause
+  ansible.builtin.pause:
+    prompt: "pause"
+    echo: false

--- a/roles/monitoring_sap/tasks/port-connectivity-check.yml
+++ b/roles/monitoring_sap/tasks/port-connectivity-check.yml
@@ -1,0 +1,52 @@
+---
+# This playbook checks port connectivity to SAP System ports on the monitoring host
+- name: This playbook deploys the SAP monitoring configuration on the monitoring host
+  ansible.builtin.debug:
+      msg: "SAP monitoring configuration using the sap_monitoring_nr: {{ sap_monitoring_nr }}"
+
+- name: Check existence  of the SAP variables in the file sample-sap-monitoring-parameters.yml
+  ansible.builtin.fail:
+      msg: 'variable {{ sap_item }} is not defined in the file sample-sap-monitoring-parameters.yml'
+  when: not sap_item
+  # when:  sap_item is not defined
+  # when: "{{ sap_item }}" is not defined
+  loop_control:
+      loop_var: sap_item
+  loop:
+      - "{{ sap_monitoring_nr }}"
+      - "{{ ibmcloud_monitoring_instance_url }}"
+      - "{{ ibmcloud_monitoring_authorization_credentials }}"
+      - "{{ sap_hana_ip }}"
+      - "{{ sap_hana_http_port }}"
+      - "{{ sap_hana_sql_systemdb_port }}"
+      - "{{ sap_hana_sql_systemdb_user }}"
+      - "{{ sap_hana_sql_systemdb_password }}"
+      - "{{ sap_ascs_ip }}"
+      - "{{ sap_ascs_http_port }}"
+      - "{{ sap_app_server }}"
+
+- name: Install netcat-openbsd
+  ansible.builtin.zypper:
+      name: netcat-openbsd
+      state: present
+  tags: netcat-openbsd
+
+- name: Check network connectivity to SAP System, fail if ports are not open
+  ansible.builtin.command: "{{ netcat_item }}"
+  loop_control:
+      loop_var: netcat_item
+  loop:
+      - "netcat -vz {{ sap_hana_ip }} {{ sap_hana_sql_systemdb_port }}"
+      - "netcat -vz {{ sap_hana_ip }} {{ sap_hana_http_port }}"
+      - "netcat -vz {{ sap_ascs_ip }} {{ sap_ascs_http_port }}"
+      # - "netcat -vz {{ sap_hana_ip }} 99"
+  register: command_result
+  failed_when: "'failed' in command_result.stderr"
+
+- name: Check network connectivity to SAP App servers, fail if ports are not open
+  ansible.builtin.command: "netcat -vz {{ server_item.ip }} {{ server_item.port }}"
+  loop_control:
+      loop_var: server_item
+  loop: "{{ sap_app_server }}"
+  register: command_result
+  failed_when: "'failed' in command_result.stderr"

--- a/roles/monitoring_sap/tasks/prometheus-agent-configuration.yml
+++ b/roles/monitoring_sap/tasks/prometheus-agent-configuration.yml
@@ -1,0 +1,51 @@
+---
+# This playbook contains  prometheus-agent configuration on the monitoring host
+
+- name: Install golang-github-prometheus-prometheus
+  ansible.builtin.zypper:
+    name: golang-github-prometheus-prometheus
+    state: present
+  tags: golang-github-prometheus-prometheus
+
+- name: Create and set permissions to prometheus agent directory /opt/prometheus
+  ansible.builtin.file:
+    path: /opt/prometheus
+    state: directory
+    owner: prometheus
+    group: prometheus
+    mode: '0750'
+    recurse: true
+
+- name: Copy systemd-file /etc/systemd/system/prometheus@.service
+  ansible.builtin.template:
+    src: prometheus@.service.j2
+    dest: /etc/systemd/system/prometheus@.service
+    owner: root
+    group: root
+    mode: '0640'
+
+- name: Force systemd to reread systemd configs
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Set permissions to prometheus configuration  directory /etc/prometheus/
+  ansible.builtin.file:
+    path: /etc/prometheus
+    state: directory
+    owner: prometheus
+    group: prometheus
+    mode: '0740'
+
+- name: Copy prometheus agent configuration to /etc/prometheus
+  ansible.builtin.template:
+    src: prometheus-sap_monitoring_nr.j2
+    dest: /etc/prometheus/{{ sap_monitoring_nr }}.yml
+    owner: prometheus
+    group: prometheus
+    mode: '0640'
+
+- name: Start systemd daemon prometheus@<sap_monitoring_nr>
+  ansible.builtin.systemd:
+    name: prometheus@{{ sap_monitoring_nr }}
+    state: started
+    enabled: true

--- a/roles/monitoring_sap/tasks/repos-activation.yml
+++ b/roles/monitoring_sap/tasks/repos-activation.yml
@@ -1,0 +1,17 @@
+---
+# The role common will activate SLES OS Repos and install the prometheus packages
+
+- name: Install netcat-openbsd
+  ansible.builtin.zypper:
+    name: netcat-openbsd
+    state: present
+  tags: netcat-openbsd
+
+- name: Activate SLES repo SLE-Module-SAP-Applications15-SP5-Updates & SLE-Module-Packagehub-Subpackages15-SP5-Pool
+  ansible.builtin.command: "{{ item_cmd }}"
+  loop:
+    - hostname
+    - /usr/sbin/SUSEConnect -p sle-module-sap-applications/15.5/x86_64
+    - /usr/sbin/SUSEConnect -p PackageHub/15.5/x86_64
+  loop_control:
+    loop_var: item_cmd

--- a/roles/monitoring_sap/tasks/sap-hana-client-installation.yml
+++ b/roles/monitoring_sap/tasks/sap-hana-client-installation.yml
@@ -1,0 +1,35 @@
+---
+# The role will install ths SAP-HANA-client and SAP hdbcli which is used by hanadb_exporter
+
+- name: Install python3-pip
+  ansible.builtin.zypper:
+    name: python3-pip
+    state: present
+  tags: python3-pip
+
+- name: Chmod 750 on files in  /root/sap/ (expecting file in /root/sap)
+  ansible.builtin.file:
+    path: /root/sap/
+    state: directory
+    owner: root
+    group: root
+    mode: '0750'
+    recurse: true
+
+- name: Extract the SAP HANA Client from the SAR-file with SAPCAR
+  ansible.builtin.shell:
+    cmd: "/root/sap/SAPCAR_*.EXE -xvf /root/sap/IMDB_CLIENT*.SAR"
+    chdir: /root/sap/
+
+- name: Executing hdbinst to install the SAP HANA client
+  ansible.builtin.command:
+    cmd: "/root/sap/SAP_HANA_CLIENT/hdbinst --path=/usr/sap/hdbclient"
+    chdir: /root/sap/SAP_HANA_CLIENT/
+
+- name: Install the SAP HANA python driver
+  ansible.builtin.shell: "pip install /usr/sap/hdbclient/hdbcli-*.tar.gz"
+
+- name: Allow execution of hdbcli to non-root users
+  ansible.builtin.shell:
+    cmd: "chmod -R a+rx /usr/lib64/python3.*/site-packages/hdbcli/*"
+    #warn: false

--- a/roles/monitoring_sap/tasks/sap-host-exporter-configuration.yml
+++ b/roles/monitoring_sap/tasks/sap-host-exporter-configuration.yml
@@ -1,0 +1,72 @@
+---
+# This playbook contains all sap_host_exporter (HANA, ASCS, ABAP) configuration.
+
+- name: Install prometheus-sap_host_exporter
+  ansible.builtin.zypper:
+    name: prometheus-sap_host_exporter
+    state: present
+  tags: prometheus-sap_host_exporter
+
+- name: Configure sap_host_exporter file HANA
+  ansible.builtin.template:
+    src: sap_host_exporter-HANA.conf.j2
+    dest: /etc/sap_host_exporter/sap_host_exporter-{{ sap_monitoring_nr }}-HANA.yaml
+    owner: root
+    group: root
+    mode: '0600'
+  tags: prometheus-sap_host_exporter HANA
+
+- name: Configure sap_host_exporter file ASCS
+  ansible.builtin.template:
+    src: sap_host_exporter-ASCS.conf.j2
+    dest: /etc/sap_host_exporter/sap_host_exporter-{{ sap_monitoring_nr }}-ASCS.yaml
+    owner: root
+    group: root
+    mode: '0600'
+  tags: prometheus-sap_host_exporter ASCS
+
+- name: Configure sap_host_exporter DI
+  ansible.builtin.template:
+    src: sap_host_exporter-DI.conf.j2
+    dest: /etc/sap_host_exporter/sap_host_exporter-{{ sap_monitoring_nr }}-DI-{{ item.sap_app_server_nr }}.yaml
+    owner: root
+    group: root
+    mode: '0600'
+  loop_control:
+    loop_var: item
+  loop: "{{ sap_app_server }}"
+  tags: prometheus-sap_host_exporter DI
+
+- name: Configure systemd-daemon to sap_host_exporter
+  ansible.builtin.template:
+    src: sap_host_exporter@.service.j2
+    dest: /etc/systemd/system/sap_host_exporter@.service
+    owner: root
+    group: root
+    mode: '0640'
+
+- name: Force systemd to reread configs
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Start daemon sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-HANA
+  ansible.builtin.systemd:
+    name: sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-HANA
+    state: started
+    enabled: true
+
+- name: Start daemon sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-ASCS
+  ansible.builtin.systemd:
+    name: sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-ASCS
+    state: started
+    enabled: true
+
+- name: Start daemon all sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-DI
+  ansible.builtin.systemd:
+    name: sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-DI-{{ daemon_item.sap_app_server_nr }}
+    state: started
+    enabled: true
+  loop_control:
+    loop_var: daemon_item
+  loop: "{{ sap_app_server }}"
+  tags: prometheus-sap_host_exporter DI

--- a/roles/monitoring_sap/tasks/sap-monitoring-configuration-deletion.yml
+++ b/roles/monitoring_sap/tasks/sap-monitoring-configuration-deletion.yml
@@ -1,0 +1,74 @@
+# This playbook will delete one monitoring configuration on the monitoring host
+
+- name: This playbook deletes one SAP monitoring configuration on the monitoring host
+  ansible.builtin.debug:
+    msg: "SAP monitoring number to delete: {{ sap_monitoring_nr }}"
+  when: sap_monitoring_action == "delete"
+
+- name: Stop and disable systemd daemon prometheus@<sap_monitoring_nr>
+  ansible.builtin.systemd:
+    name: prometheus@{{ sap_monitoring_nr }}
+    state: stopped
+    enabled: false
+
+- name: Stop and disable systemd daemon prometheus-hanadb_exporter@config-{{ sap_monitoring_nr }}-SQL
+  ansible.builtin.systemd:
+    name: prometheus-hanadb_exporter@config-{{ sap_monitoring_nr }}-SQL
+    state: stopped
+    enabled: false
+
+- name: Stop and disable systemd daemon sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-ASCS
+  ansible.builtin.systemd:
+    name: sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-ASCS
+    state: stopped
+    enabled: false
+
+- name: Stop and disable systemd daemon sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-HANA
+  ansible.builtin.systemd:
+    name: sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-HANA
+    state: stopped
+    enabled: false
+
+- name: Disable systemd daemon sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-DI-*
+  ansible.builtin.shell: rm -f /etc/systemd/system/multi-user.target.wants/sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-DI-*.service
+  args:
+    executable: /bin/bash
+    warn: false
+
+- name: Stop systemd daemon sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-DI-*
+  ansible.builtin.shell: systemctl stop sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-DI*
+  args:
+    executable: /bin/bash
+    warn: false
+
+# module systemd: globbing for start, but not for disable
+#  systemctl status sap_host_exporter@sap_host_exporter-{{ sap_monitoring_nr }}-DI*
+# /etc/systemd/system/multi-user.target.wants/sap_host_exporter@sap_host_exporter-03-DI-2.service
+
+### delete configuration files
+
+- name: Delete file /etc/prometheus/{{ sap_monitoring_nr }}.yml
+  ansible.builtin.file:
+    path: /etc/prometheus/{{ sap_monitoring_nr }}.yml
+    state: absent
+
+- name: Delete file /etc/hanadb_exporter/config-{{ sap_monitoring_nr }}-SQL.json
+  ansible.builtin.file:
+    path: /etc/hanadb_exporter/config-{{ sap_monitoring_nr }}-SQL.json
+    state: absent
+
+- name: Delete file /etc/sap_host_exporter/sap_host_exporter-{{ sap_monitoring_nr }}-ASCS.yaml
+  ansible.builtin.file:
+    path: /etc/sap_host_exporter/sap_host_exporter-{{ sap_monitoring_nr }}-ASCS.yaml
+    state: absent
+
+- name: Delete file /etc/sap_host_exporter/sap_host_exporter-{{ sap_monitoring_nr }}-HANA.yaml
+  ansible.builtin.file:
+    path: /etc/sap_host_exporter/sap_host_exporter-{{ sap_monitoring_nr }}-HANA.yaml
+    state: absent
+
+- name: Delete file /etc/sap_host_exporter/sap_host_exporter-{{ sap_monitoring_nr }}-DI-*.yaml
+  ansible.builtin.shell: rm -f /etc/sap_host_exporter/sap_host_exporter-{{ sap_monitoring_nr }}-DI-*.y*ml
+  args:
+    executable: /bin/bash
+    warn: false

--- a/roles/monitoring_sap/templates/hanadb_exporter-config-SQL.json.conf.j2
+++ b/roles/monitoring_sap/templates/hanadb_exporter-config-SQL.json.conf.j2
@@ -1,0 +1,15 @@
+{
+  "listen_address": "0.0.0.0",
+  "exposition_port": 5{{ sap_monitoring_nr }}02,
+  "multi_tenant": false,
+  "_comment_multi_tenant": "true, if you want another 1000 metrics",
+  "sap_monitoring_solution_name": "{{ sap_monitoring_solution_name }}",
+  "timeout": 30,
+  "hana": {
+    "host":  "{{ sap_hana_ip }}",
+    "port": {{ sap_hana_sql_systemdb_port }},
+    "userkey": "MONITORING{{ sap_monitoring_nr }}KEY",
+    "ssl": true,
+    "ssl_validate_cert": false
+  }
+}

--- a/roles/monitoring_sap/templates/prometheus-sap_monitoring_nr.j2
+++ b/roles/monitoring_sap/templates/prometheus-sap_monitoring_nr.j2
@@ -1,0 +1,29 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 20s
+
+remote_write:
+- url: "{{ ibmcloud_monitoring_instance_url }}"
+  authorization:
+    credentials: "{{ ibmcloud_monitoring_authorization_credentials }}"
+  write_relabel_configs:
+    - target_label: instance
+      replacement: 'SAP-{{ sap_monitoring_nr }}-{{ sap_monitoring_solution_name }}'
+      # sap_monitoring_solution_name: {{ sap_monitoring_solution_name }}
+
+scrape_configs:
+  - job_name: "hanadb_exporter"
+    static_configs:
+       - targets: ['localhost:5{{ sap_monitoring_nr }}02']
+    relabel_configs:
+      - target_label: domain
+        replacement: 'SAP'
+
+  - job_name: "sap_host_exporter"
+    static_configs:
+       - targets: ['localhost:5{{ sap_monitoring_nr }}03','localhost:5{{ sap_monitoring_nr }}04','localhost:5{{ sap_monitoring_nr }}05']
+    # 05 – n : as many as existing Application server
+
+    relabel_configs:
+      - target_label: domain
+        replacement: 'SAP'

--- a/roles/monitoring_sap/templates/prometheus@.service.j2
+++ b/roles/monitoring_sap/templates/prometheus@.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=PrometheusAfter=network.target
+
+[Service]
+User=prometheus
+Group=prometheus
+Type=simple
+Restart=always
+ExecStart=/usr/bin/prometheus --config.file=/etc/prometheus/%i.yml --storage.agent.path=/opt/prometheus/%i --enable-feature=agent --web.listen-address=localhost:5%i01
+# --web.listen-address=localhost:5${{ sap_monitoring_nr }}01
+ExecReload=/bin/kill -HUP $MAINPID
+TimeoutStopSec=20s
+SendSIGKILL=no
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/monitoring_sap/templates/sap_host_exporter-ASCS.conf.j2
+++ b/roles/monitoring_sap/templates/sap_host_exporter-ASCS.conf.j2
@@ -1,0 +1,9 @@
+# The listening TCP/IP address and port.
+address: "0.0.0.0"
+port: "5{{ sap_monitoring_nr }}04"
+log-level: "info"# ASCS instance
+# sap_monitoring_solution_name: {{ sap_monitoring_solution_name }}
+sap-control-url: "http://{{ sap_ascs_ip }}:{{ sap_ascs_http_port }}"
+# HTTP Basic Authentication credentials for the SAPControl web service,
+# e.g. <sid>adm user and password.
+# Make sure this file permissions are set to 600.

--- a/roles/monitoring_sap/templates/sap_host_exporter-DI-01.conf.j2
+++ b/roles/monitoring_sap/templates/sap_host_exporter-DI-01.conf.j2
@@ -1,0 +1,9 @@
+# The listening TCP/IP address and port.
+address: "0.0.0.0"
+port: "5{{ sap_monitoring_nr }}05"
+log-level: "info"
+# sap_monitoring_solution_name: {{ sap_monitoring_solution_name }}
+# DI instance 01  (89 metrics dispatcher server + resources)
+sap-control-url: "http://{{ item.ip }}:{{ item.port }}"
+# HTTP Basic Authentication credentials for the SAPControl web service, e.g. <sid>adm user and password.
+# Make sure this file's permissions are set to 600.

--- a/roles/monitoring_sap/templates/sap_host_exporter-DI.conf.j2
+++ b/roles/monitoring_sap/templates/sap_host_exporter-DI.conf.j2
@@ -1,0 +1,7 @@
+# The listening TCP/IP address and port.
+address: "0.0.0.0"
+port: "5{{ sap_monitoring_nr }}{{ item.sap_app_server_nr + 4 }}"
+log-level: "info"
+# sap_monitoring_solution_name: {{ sap_monitoring_solution_name }}
+# DI instance
+sap-control-url: "http://{{ item.ip }}:{{ item.port }}"

--- a/roles/monitoring_sap/templates/sap_host_exporter-HANA.conf.j2
+++ b/roles/monitoring_sap/templates/sap_host_exporter-HANA.conf.j2
@@ -1,0 +1,9 @@
+# The listening TCP/IP address and port.
+address: "0.0.0.0"
+port: "5{{ sap_monitoring_nr }}03"
+log-level: "info"
+# sap_monitoring_solution_name: {{ sap_monitoring_solution_name }}
+sap-control-url: "http://{{ sap_hana_ip }}:{{ sap_hana_http_port }}"
+# HTTP Basic Authentication credentials for the SAPControl web service,
+# e.g.<sid>adm user and password.
+# Make sure this file's permissions are set to 600.

--- a/roles/monitoring_sap/templates/sap_host_exporter@.service.j2
+++ b/roles/monitoring_sap/templates/sap_host_exporter@.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Prometheus sap_host_exporter for Netweaver clusters metrics
+After=network.target
+Documentation=https://github.com/SUSE/sap_host_exporter
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/usr/bin/sap_host_exporter --config /etc/sap_host_exporter/%i.yaml
+ExecReload=/bin/kill -HUP
+
+[Install]
+WantedBy=multi-user.target
+DefaultInstance=default


### PR DESCRIPTION
…n.yml, vars requires copy to role/../vars/main.yml, call:  ansible-playbook playbooks/sample-monitoring-sap.yml, without connection, without hostlist


with main.yml in the role, the execution shows skipped tasks.
Of course, skipped taks can not be hidden.
Without main.yml  skipped taks would not occur.
I consider it a bad dsign to want both, one role and still use main.yml.
