### PR TITLE
feat: introduce new optional variables for proxy for rhel os registration

### DIFF
--- a/roles/powervs_os_registration/README.md
+++ b/roles/powervs_os_registration/README.md
@@ -32,7 +32,7 @@ Install the below collections.
 
 | Name       | Type       |Example                                     | Description                        |
 |------------|------------|--------------------------------------------|-----------------------------------|
-| byol  | Object   | <br>byol:<br>&nbsp;&nbsp;username:`username`<br> &nbsp;&nbsp;password:`password`<br> | BYOL for RHEL/SLES. For RHEL provide username and password. For SLES provide email as username and activation code as password. Do not provide it for Full Linux Subscription |
+| byol  | Object   | <br>byol:<br>&nbsp;&nbsp;username:`username`<br> &nbsp;&nbsp;password:`password`<br> &nbsp;&nbsp;password:`server_proxy_hostname`<br> &nbsp;&nbsp;password:`server_proxy_port`<br>| BYOL for RHEL/SLES. For RHEL provide username and password. If your machine does not have public internet access, you also need to provide a hostname and port of a proxy server with a valid route to the registration servers. For SLES provide email as username and activation code as password. Do not provide it for Full Linux Subscription |
 | fls   | Boolean  | fls: true | if true, performs Full Linux Subscription. Do not provide if for BYOL|
 
 # Installation Guide

--- a/roles/powervs_os_registration/tasks/rhel_byol.yml
+++ b/roles/powervs_os_registration/tasks/rhel_byol.yml
@@ -24,6 +24,8 @@
         state: present
         username: "{{ byol.username }}"
         password: "{{ byol.password }}"
+        server_proxy_hostname: "{{ byol.server_proxy_hostname | default(omit) }}"
+        server_proxy_port: "{{ byol.server_proxy_port | default(omit) }}"
         release: "{{ ansible_distribution_version }}"
         auto_attach: true
         force_register: true


### PR DESCRIPTION
"The community-general. redhat_subscription module does not automatically inherit proxy settings from your environment variables (HTTP_PROXY / HTTPS_PROXY ) or the system configuration. It expects you to explicity define the proxy settings as part of the module parameters."