### PR TITLE
fix: hide secret when creating hana keystore

### DIFF
--- a/roles/monitoring_sap/docs/HOWTO-configure-SAP-system-services.md
+++ b/roles/monitoring_sap/docs/HOWTO-configure-SAP-system-services.md
@@ -33,52 +33,51 @@ List the configured webmethods (using the instance numbers extracted with lssap 
 
 `sapcontrol -nr <instance-nr> -function ParameterValue service/protectedwebmethods`
 
-If this shows the result:
-`SDEFAULT -GetQueueStatistic -ABAPGetWPTable -EnqGetStatistic -GetProcessList - GetEnvironment –ABAPGetSystemWPTable`
+If this shows the result: <br>
+`SDEFAULT -GetQueueStatistic -ABAPGetWPTable -EnqGetStatistic -GetProcessList - GetEnvironment –ABAPGetSystemWPTable` <br>
 then no other configuration is required.
 Any other result requires to add one line to the configuration file.
 
-Show the configuration files
+Show the configuration files <br>
 `sapcontrol -nr <instance-nr> -function ListConfigFiles`
 
 3 config files of the instance are listed,
-edit the file that does not list DEFAULT.PFL or secinfo
-(it is listed as well with `ps aux | grep -I sapstart `)
+edit the file that does not list 'DEFAULT.PFL' or 'secinfo' <br>
+(it is listed as well with `ps aux | grep -I sapstart `) <br>
 
-Before changing the configuration of the specific serive it is best to stop the service:
+Before changing the configuration of the specific serive it is best to stop the service: <br>
 
-`sapcontrol -nr  instance_nr sapstart -function StopSystem`
+`sapcontrol -nr  instance_nr sapstart -function StopSystem` <br>
 
-
-Add these lines as hithero owner of the configuration file:
+Add these lines as hithero owner of the configuration file: <br>
 
 (The config text must be put in one single line or change the line if an entry already exists)
-“'service/protectedwebmethods'” after the SETENV parameters (the line service is one line only):
+“'service/protectedwebmethods'” after the SETENV parameters (the line service is one line only): <br>
 
 ```
 # IBM SAP monitoring
 service/protectedwebmethods = SDEFAULT -GetQueueStatistic -ABAPGetWPTable -EnqGetStatistic -GetProcessList -GetEnvironment -ABAPGetSystemWPTable
 ```
 
-Save the config file without changing the file name.
-Restart the corresponding services:
-`sapcontrol -nr <instance-nr> sapstart -function RestartService`
+Save the config file without changing the file name. <br>
+Restart the corresponding services: <br>
+`sapcontrol -nr <instance-nr> sapstart -function RestartService` <br>
 
-This may take some time, to check the status:
-`sapcontrol -nr sapstart -function GetSystemInstanceList`
+This may take some time, to check the status: <br>
+`sapcontrol -nr sapstart -function GetSystemInstanceList` <br>
 
-The status will show GREEN/ GRAY /YELLOW.
+The status will show GREEN/ GRAY /YELLOW. <br>
 If the service does not return to GREEN, the chapter troubleshooting will list some options.
-Restarting the Service may fail in some cases.
-Then start the service:
+Restarting the Service may fail in some cases. <br>
+Then start the service: <br>
 
 ```
 sapcontrol -nr service -function StartService instance_name
 # The value of instance_name is listed in the sapstart configuration file.
 ```
 
-List again the configured webmethods (using the instance numbers extracted with lssap)
+List again the configured webmethods (using the instance numbers extracted with lssap) <br>
 `sapcontrol -nr <instance-nr> -function ParameterValue service/protectedwebmethods`
 
-This is the desired result:
+This is the desired result: <br>
 `SDEFAULT -GetQueueStatistic -ABAPGetWPTable -EnqGetStatistic -GetProcessList - GetEnvironment -ABAPGetSystemWPTable`

--- a/roles/monitoring_sap/tasks/hanadb-exporter-configuration.yml
+++ b/roles/monitoring_sap/tasks/hanadb-exporter-configuration.yml
@@ -20,6 +20,7 @@
 - name: Create a sap-hana-keystore for the <sap_monitoring_nr> {{ sap_monitoring_nr }}
   ansible.builtin.shell:
     cmd: "/usr/sap/hdbclient/hdbuserstore SET MONITORING{{ sap_monitoring_nr }}KEY {{ sap_hana_ip }}:{{ sap_hana_sql_systemdb_port }}@SYSTEMDB {{ sap_hana_sql_systemdb_user }} {{ sap_hana_sql_systemdb_password }}"
+  no_log: true
 
 - name: Check sap-hana-keystore for 'MONITORING{{ sap_monitoring_nr }}KEY'
   ansible.builtin.shell:


### PR DESCRIPTION
added 'no_log' to tasks/hanadb-exporter-configuration.yml  task ' Create a sap-hana-keystore'.
Small changes to README.